### PR TITLE
🔧 Modified default env from prod to stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ export const mintNFT = async (quantity, metadata) => {
   // Create a new provider, which is an abstraction of a connection to the Ethereum network.
   const provider = importProvider();
   // Select 'dev', 'stage', or 'prod' environment to determine which smart contract to use. Default is 'prod'.
-  const env = "prod";
+  const env = "stage";
   // Get the appropriate Freeport contract address, based on environment selected above.
   const contractAddress = await getFreeportAddress(provider, env);
   // Create an instance of the Freeport contract using the provider and Freeport contract address
@@ -306,7 +306,7 @@ export const attachNftToCid = async (nftId, cid) => {
   // Create a new provider, which is an abstraction of a connection to the Ethereum network.
   const provider = importProvider();
   // Select 'dev', 'stage', or 'prod' environment to determine which smart contract to use. Default is 'prod'.
-  const env = "prod";
+  const env = "stage";
   // Get the appropriate Freeport contract address, based on environment selected above.
   const contractAddress = await getNFTAttachmentAddress(provider, env);
   // Create an instance of the Freeport contract using the provider and Freeport contract address

--- a/freeport-nft-minter/src/actions.js
+++ b/freeport-nft-minter/src/actions.js
@@ -107,7 +107,7 @@ export const mintNFT = async (quantity, metadata) => {
   // Create a new provider, which is an abstraction of a connection to the Ethereum network.
   const provider = importProvider();
   // Select 'dev', 'stage', or 'prod' environment to determine which smart contract to use. Default is 'prod'.
-  const env = "prod";
+  const env = "stage";
   // Get the appropriate Freeport contract address, based on environment selected above.
   const contractAddress = await getFreeportAddress(provider, env);
   // Create an instance of the Freeport contract using the provider and Freeport contract address
@@ -129,7 +129,7 @@ export const attachNftToCid = async (nftId, cid) => {
   // Create a new provider, which is an abstraction of a connection to the Ethereum network.
   const provider = importProvider();
   // Select 'dev', 'stage', or 'prod' environment to determine which smart contract to use. Default is 'prod'.
-  const env = "prod";
+  const env = "stage";
   // Get the appropriate Freeport contract address, based on environment selected above.
   const contractAddress = await getNFTAttachmentAddress(provider, env);
   // Create an instance of the Freeport contract using the provider and Freeport contract address


### PR DESCRIPTION
The default env is `prod`, which induces an error while doing the tutorial.
It should be `stage` as everything is already configured for staging environment.